### PR TITLE
transfer repo from atlasgong to MindVista org

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -8,7 +8,7 @@ const Configuration: UserConfig = {
     rules: {
         "type-enum": [RuleConfigSeverity.Error, "always", ["build", "ci", "cms", "test", "merge", "content", "feat", "fix", "resp", "a11y", "ui", "ux", "perf", "sec", "refactor", "seo", "legal", "docs", "other"]],
     },
-    helpUrl: "https://github.com/atlasgong/mindvista/wiki/Commit-Guidelines",
+    helpUrl: "https://github.com/MindVista/website/wiki/Commit-Guidelines",
     defaultIgnores: true,
 };
 

--- a/.env.development.example
+++ b/.env.development.example
@@ -1,6 +1,6 @@
 APP_ENV="development"
 
-# see https://github.com/atlasgong/mindvista/wiki#getting-started for more information
+# see https://github.com/MindVista/website/wiki#getting-started for more information
 
 # SELF SOURCABLE VARIABLES START -------------------------------
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,7 +78,7 @@ jobs:
                       ${{ steps.commitlint.outputs.output }}
                       \`\`\`
 
-                      Please see https://github.com/atlasgong/mindvista/wiki/Commit-Guidelines for more information.`;
+                      Please see https://github.com/MindVista/website/wiki/Commit-Guidelines for more information.`;
 
                       await github.rest.issues.createComment({
                         issue_number: context.issue.number,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@ Thank you and happy coding!
 
 # General Guidelines
 
-[Skip to documentation.](https://github.com/atlasgong/mindvista/wiki/)
-New to this repo? See [Getting Started](https://github.com/atlasgong/mindvista/wiki#getting-started) to set up your local server.
+[Skip to documentation.](https://github.com/MindVista/website/wiki/)
+New to this repo? See [Getting Started](https://github.com/MindVista/website/wiki#getting-started) to set up your local server.
 
-Before committing, see our [Conventional Commit Guidelines](https://github.com/atlasgong/mindvista/wiki/Commit-Guidelines).
+Before committing, see our [Conventional Commit Guidelines](https://github.com/MindVista/website/wiki/Commit-Guidelines).
 
 Please write clear and concise code. We use [Prettier](https://prettier.io/docs/en/) for formatting. Ensure that files are well-commented when necessary.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This project includes certain open-source software components, each licensed sep
 
 ## Got questions?
 
-- For **general inquiries** or **suggestions** regarding the **repository**, **code**, or **web app**, create an issue [here](https://github.com/atlasgong/mindvista/issues/new).
-- For **security-related matters** regarding the code you see in this repository, privately report a vulnerability [here](https://github.com/atlasgong/mindvista/security/advisories/new).
+- For **general inquiries** or **suggestions** regarding the **repository**, **code**, or **web app**, create an issue [here](https://github.com/MindVista/website/issues/new).
+- For **security-related matters** regarding the code you see in this repository, privately report a vulnerability [here](https://github.com/MindVista/website/security/advisories/new).
 - For **private matters** regarding the **respository**, **code**, or **web app**, contact Atlas or Murad directly: [mindvista@atlasgong.dev](mailto:mindvista@atlasgong.dev),
   [murad.novruzov1899@gmail.com](mailto:murad.novruzov1899@gmail.com)
 - For **all other inquiries**, contact MindVista [here](https://mindvista.ca/contact).

--- a/src/app/(app)/(pages)/contact/page.tsx
+++ b/src/app/(app)/(pages)/contact/page.tsx
@@ -28,7 +28,7 @@ export default function ContactPage() {
             label: "LinkedIn",
         },
         {
-            href: "https://github.com/atlasgong/mindvista",
+            href: "https://github.com/MindVista/website",
             icon: FaGithub,
             label: "GitHub",
         },

--- a/src/app/(app)/components/Footer.tsx
+++ b/src/app/(app)/components/Footer.tsx
@@ -152,7 +152,7 @@ function LegalBar() {
             label: "LinkedIn",
         },
         {
-            href: "https://github.com/atlasgong/mindvista",
+            href: "https://github.com/MindVista/website",
             icon: FaGithub,
             label: "GitHub",
         },

--- a/src/app/(app)/components/navbar/NavBar.tsx
+++ b/src/app/(app)/components/navbar/NavBar.tsx
@@ -106,7 +106,7 @@ function NavMenu({ nav }: NavMenuProps) {
             label: "LinkedIn",
         },
         {
-            href: "https://github.com/atlasgong/mindvista",
+            href: "https://github.com/MindVista/website",
             icon: FaGithub,
             label: "GitHub",
         },

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
     // CHANGES MADE TO THIS COMPONENT MUST BE MIRRORED IN src/app/not-found.tsx.
-    // See https://github.com/atlasgong/mindvista/wiki/Miscellaneous#404-page-handling
+    // See https://github.com/MindVista/website/wiki/Miscellaneous#404-page-handling
     return (
         <html lang="en" suppressHydrationWarning>
             <head>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -36,7 +36,7 @@ const messages = [
 
 // This is the "acting" "default" component for the NotFound page.
 // It may be freely edited as if it were any other component.
-// See https://github.com/atlasgong/mindvista/wiki/Miscellaneous#404-page-handling for more details.
+// See https://github.com/MindVista/website/wiki/Miscellaneous#404-page-handling for more details.
 function NotFoundComponent() {
     const randomMessage = messages[Math.floor(Math.random() * messages.length)];
 
@@ -56,7 +56,7 @@ export default function NotFound() {
     // CHANGES MUST ONLY BE MADE BELOW IF MIRRORED FROM ONE OF:
     // - src/app/(app)/(pages)/layout.tsx or
     // - src/app/(app)/layout.tsx
-    // See https://github.com/atlasgong/mindvista/wiki/Miscellaneous#404-page-handling
+    // See https://github.com/MindVista/website/wiki/Miscellaneous#404-page-handling
     return (
         // APP LAYOUT START
         <html lang="en" suppressHydrationWarning>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update repository URLs from 'atlasgong' to 'MindVista' across documentation, code comments, and social media links.
> 
>   - **Documentation Links**:
>     - Updated URLs in `.commitlintrc.ts`, `.env.development.example`, `CONTRIBUTING.md`, and `README.md` to point to `https://github.com/MindVista/website` instead of `https://github.com/atlasgong/mindvista`.
>   - **Code Comments**:
>     - Updated comments in `layout.tsx` and `not-found.tsx` to reflect the new repository URL.
>   - **Social Media Links**:
>     - Updated GitHub links in `page.tsx`, `Footer.tsx`, and `NavBar.tsx` to `https://github.com/MindVista/website`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=MindVista%2Fwebsite&utm_source=github&utm_medium=referral)<sup> for 72dc5cb87c1cead20739322b807087b8d8320e0f. You can [customize](https://app.ellipsis.dev/MindVista/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->