### PR TITLE
ci: disable commit type enforcement

### DIFF
--- a/.commitlintrc.ts
+++ b/.commitlintrc.ts
@@ -6,7 +6,11 @@ const Configuration: UserConfig = {
     parserPreset: "conventional-changelog-atom",
     formatter: "@commitlint/format",
     rules: {
-        "type-enum": [RuleConfigSeverity.Error, "always", ["build", "ci", "cms", "test", "merge", "content", "feat", "fix", "resp", "a11y", "ui", "ux", "perf", "sec", "refactor", "seo", "legal", "docs", "other"]],
+        "type-enum": [RuleConfigSeverity.Disabled, "always", ["build", "ci", "cms", "test", "merge", "content", "feat", "fix", "resp", "a11y", "ui", "ux", "perf", "sec", "refactor", "seo", "legal", "docs", "other"]],
+        "type-empty": [RuleConfigSeverity.Disabled],
+        "subject-empty": [RuleConfigSeverity.Disabled],
+        "header-min-length": [RuleConfigSeverity.Error, "always", 12],
+        "header-max-length": [RuleConfigSeverity.Error, "always", 72],
     },
     helpUrl: "https://github.com/atlasgong/mindvista/wiki/Commit-Guidelines",
     defaultIgnores: true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,6 @@ Thank you and happy coding!
 [Skip to documentation.](https://github.com/atlasgong/mindvista/wiki/)
 New to this repo? See [Getting Started](https://github.com/atlasgong/mindvista/wiki#getting-started) to set up your local server.
 
-Before committing, see our [Conventional Commit Guidelines](https://github.com/atlasgong/mindvista/wiki/Commit-Guidelines).
-
 Please write clear and concise code. We use [Prettier](https://prettier.io/docs/en/) for formatting. Ensure that files are well-commented when necessary.
 
 ### Responsiveness


### PR DESCRIPTION
see [[Archived] Conventional Commit Guidelines](https://github.com/MindVista/website/wiki/%5BArchived%5D-Conventional-Commits-Guideline)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables commit type enforcement in `.commitlintrc.ts` and updates `CONTRIBUTING.md` accordingly.
> 
>   - **Commit Lint Configuration**:
>     - Disables `type-enum`, `type-empty`, and `subject-empty` rules in `.commitlintrc.ts`.
>     - Sets `header-min-length` to 12 and `header-max-length` to 72 in `.commitlintrc.ts`.
>   - **Contributing Guidelines**:
>     - Removes reference to Conventional Commit Guidelines in `CONTRIBUTING.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=MindVista%2Fwebsite&utm_source=github&utm_medium=referral)<sup> for bdd3efadb7467bdb6dfc1ab6c907a4b5f9a1ca68. You can [customize](https://app.ellipsis.dev/MindVista/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->