### PR TITLE
ci(backups): adjust cron schedule to run 3 times a day

### DIFF
--- a/.github/workflows/backup-payload.yml
+++ b/.github/workflows/backup-payload.yml
@@ -2,7 +2,7 @@ name: Backup Payload Database to S3
 
 on:
     schedule:
-        - cron: "13,43 * * * *" # runs every 30 minutes at hh:13 and hh:43
+        - cron: "0 0,8,16 * * *" # runs at 00:00, 08:00, and 16:00 daily
     workflow_dispatch: # allows manual triggering from GitHub UI
 
 permissions:


### PR DESCRIPTION
at 00:00, 08:00, and 16:00, instead of every hour.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts cron schedule in `backup-payload.yml` to run backups at 00:00, 08:00, and 16:00 daily.
> 
>   - **Schedule Change**:
>     - Adjusts cron schedule in `.github/workflows/backup-payload.yml` to run at 00:00, 08:00, and 16:00 daily instead of every hour.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=MindVista%2Fwebsite&utm_source=github&utm_medium=referral)<sup> for c28ff578af148299c226671c86773342270613d1. You can [customize](https://app.ellipsis.dev/MindVista/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->