### PR TITLE
fix: allow 1 letter names for form validation

### DIFF
--- a/src/app/(app)/(pages)/contact/components/ContactForm/ContactForm.tsx
+++ b/src/app/(app)/(pages)/contact/components/ContactForm/ContactForm.tsx
@@ -9,7 +9,7 @@ import useWeb3Forms from "@web3forms/react";
 
 // validation error messages
 export const ERROR_MESSAGES = {
-    nameMin: "Must be at least 2 characters long.",
+    nameMin: "Must be at least 1 character long.",
     nameMax: "Must be at most 64 characters long.",
     orgMax: "Must be at most 32 characters long.",
     emailInvalid: "You must enter a valid email address.",
@@ -22,7 +22,7 @@ export const ERROR_MESSAGES = {
 
 // define form scheme for input validation
 const schema = z.object({
-    name: z.string().min(2, { message: ERROR_MESSAGES.nameMin }).max(64, { message: ERROR_MESSAGES.nameMax }).trim(),
+    name: z.string().min(1, { message: ERROR_MESSAGES.nameMin }).max(64, { message: ERROR_MESSAGES.nameMax }).trim(),
     organization: z.optional(z.string().max(32, { message: ERROR_MESSAGES.orgMax }).trim()),
     email: z.string().email({ message: ERROR_MESSAGES.emailInvalid }).trim(),
     subject: z.string().min(4, { message: ERROR_MESSAGES.subjectMin }).max(78, { message: ERROR_MESSAGES.subjectMax }).trim(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow 1-letter names in `ContactForm.tsx` by updating validation schema and error message.
> 
>   - **Validation**:
>     - Update `ERROR_MESSAGES.nameMin` in `ContactForm.tsx` to "Must be at least 1 character long."
>     - Change `schema` in `ContactForm.tsx` to allow `name` with a minimum length of 1 character.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=MindVista%2Fwebsite&utm_source=github&utm_medium=referral)<sup> for cb6339b4861fb5a81266f564bfb28659d1b1b125. You can [customize](https://app.ellipsis.dev/MindVista/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->