### PR TITLE
fix: image modal only opens when clicking image

### DIFF
--- a/src/app/(app)/components/ImageModal.tsx
+++ b/src/app/(app)/components/ImageModal.tsx
@@ -16,16 +16,9 @@ export default function ImageModal({ url, altText, width = 1000, height = 1000, 
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     return (
-        <div
-            className={`relative cursor-pointer ${className}`}
-            onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-                if (e.target instanceof HTMLImageElement) {
-                    setIsModalOpen(true);
-                }
-            }}
-        >
+        <div className={`relative ${className}`}>
             {/* Regular Image */}
-            <Image src={url} alt={altText} width={width} height={height} className="mx-auto max-h-[40vh] min-h-[10vh] w-auto rounded-lg object-contain md:max-h-[50vh] lg:max-h-[60vh] xl:max-h-[70vh]" />
+            <Image onClick={() => setIsModalOpen(true)} src={url} alt={altText} width={width} height={height} className="mx-auto max-h-[40vh] min-h-[10vh] w-auto cursor-pointer rounded-lg object-contain md:max-h-[50vh] lg:max-h-[60vh] xl:max-h-[70vh]" />
             <p className="mt-2 text-center text-sm text-cTextOffset md:px-[4vw] lg:px-[7vw]">{altText}</p>
 
             {/* Modal */}

--- a/src/app/(app)/components/ImageModal.tsx
+++ b/src/app/(app)/components/ImageModal.tsx
@@ -16,7 +16,14 @@ export default function ImageModal({ url, altText, width = 1000, height = 1000, 
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     return (
-        <div className={`relative cursor-pointer ${className}`} onClick={() => setIsModalOpen(true)}>
+        <div
+            className={`relative cursor-pointer ${className}`}
+            onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+                if ((e.target as HTMLElement).tagName === "IMG") {
+                    setIsModalOpen(true);
+                }
+            }}
+        >
             {/* Regular Image */}
             <Image src={url} alt={altText} width={width} height={height} className="mx-auto max-h-[40vh] min-h-[10vh] w-auto rounded-lg object-contain md:max-h-[50vh] lg:max-h-[60vh] xl:max-h-[70vh]" />
             <p className="mt-2 text-center text-sm text-cTextOffset md:px-[4vw] lg:px-[7vw]">{altText}</p>

--- a/src/app/(app)/components/ImageModal.tsx
+++ b/src/app/(app)/components/ImageModal.tsx
@@ -19,7 +19,7 @@ export default function ImageModal({ url, altText, width = 1000, height = 1000, 
         <div
             className={`relative cursor-pointer ${className}`}
             onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-                if ((e.target as HTMLElement).tagName === "IMG") {
+                if (e.target instanceof HTMLImageElement) {
                     setIsModalOpen(true);
                 }
             }}


### PR DESCRIPTION
“Only triggers modal when the user clicks on the image element itself
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> In `ImageModal.tsx`, the modal now opens only when the image is clicked, using `e.target instanceof HTMLImageElement`.
> 
>   - **Behavior**:
>     - In `ImageModal.tsx`, the modal now opens only when the image is clicked, not the surrounding `div`.
>     - Uses `e.target instanceof HTMLImageElement` to check if the click target is the image.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=MindVista%2Fwebsite&utm_source=github&utm_medium=referral)<sup> for b35b57cc26ddf06b0a9c206bc59703901483e2f3. You can [customize](https://app.ellipsis.dev/MindVista/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->