### PR TITLE
ci: pr checks should use pull_request_target

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,7 +1,7 @@
 name: PR Checks
 
 on:
-    pull_request:
+    pull_request_target:
         branches:
             - "**"
     workflow_dispatch: # allows manual triggering from GitHub UI
@@ -171,7 +171,7 @@ jobs:
                   else
                       # strip trailing newlines
                       FAILED_FILES_CLEAN=$(echo "$FAILED_FILES" | sed -e 's/[[:space:]]*$//')
-                      
+
                       echo "✗ The following files need formatting:"
                       echo "$FAILED_FILES_CLEAN"
                       echo


### PR DESCRIPTION
security concerns: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

I believe it should be acceptable for use and the pros outweigh the cons. We will be careful with what future changes or additions go into the PR checks workflow.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change GitHub Actions workflow trigger from `pull_request` to `pull_request_target` in `pr-checks.yml`.
> 
>   - **Workflow Trigger**:
>     - Change event trigger from `pull_request` to `pull_request_target` in `.github/workflows/pr-checks.yml`.
>   - **Misc**:
>     - Remove trailing whitespace in `.github/workflows/pr-checks.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=MindVista%2Fwebsite&utm_source=github&utm_medium=referral)<sup> for 299032003b615f2238411f8b4fc2d5909b5d6b3a. You can [customize](https://app.ellipsis.dev/MindVista/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->