### PR TITLE
fix(194): remove unnecessary setup job

### DIFF
--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -25,23 +25,12 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-    setup:
-        name: Setup
-        outputs:
-            branch: ${{ steps.branch_name.outputs.current_branch }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Get branch name
-              id: branch_name
-              uses: tj-actions/branch-names@v8
-
     create_neon_branch:
         name: Create Neon Branch
         outputs:
             # db_url: ${{ steps.create_neon_branch.outputs.db_url }}
             # db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
             db_host_pooled: ${{ steps.create_neon_branch.outputs.db_host_pooled }}
-        needs: setup
         if: |
             (github.event_name == 'pull_request' && (
             github.event.action == 'synchronize'
@@ -55,7 +44,7 @@ jobs:
               uses: neondatabase/create-branch-action@v6
               with:
                   project_id: ${{ vars.NEON_PROJECT_ID }}
-                  branch_name: preview/pr-${{ github.event.pull_request.number || inputs.pr_number }}-${{ needs.setup.outputs.branch }}
+                  branch_name: preview/pr-${{ github.event.pull_request.number || inputs.pr_number }}
                   api_key: ${{ secrets.NEON_API_KEY }}
 
     # The step above creates a new Neon branch.
@@ -297,7 +286,6 @@ jobs:
 
     delete_neon_branch:
         name: Delete Neon Branch
-        needs: setup
         if: github.event_name == 'pull_request' && github.event.action == 'closed'
         runs-on: ubuntu-latest
         steps:
@@ -305,5 +293,5 @@ jobs:
               uses: neondatabase/delete-branch-action@v3
               with:
                   project_id: ${{ vars.NEON_PROJECT_ID }}
-                  branch: preview/pr-${{ github.event.pull_request.number || inputs.pr_number }}-${{ needs.setup.outputs.branch }}
+                  branch: preview/pr-${{ github.event.pull_request.number || inputs.pr_number }}
                   api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
PR num is sufficient enough for uniqueness, and we didnt have any use for the postpended branch name anyways