### PR TITLE
ci(fix): allow retriggering workflows on PRs from forks

### DIFF
--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -1,19 +1,12 @@
 name: Create/Delete Branch for Pull Request
 
 on:
-    pull_request: # skips automatically for forks, requires manual triggering via workflow_dispatch
+    pull_request_target: # security is handled at `check_perms` job
         types:
             - opened
             - reopened
             - synchronize
             - closed
-
-    workflow_dispatch: # manual triggering for external fork PRs
-        inputs:
-            pr_number:
-                description: "Pull Request Number"
-                required: true
-                type: number
 
 permissions:
     contents: write
@@ -25,8 +18,28 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+    check_perms:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Get User Permission
+            id: checkAccess
+            uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103
+            with:
+              require: write
+              username: ${{ github.triggering_actor }}
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          - name: Check User Permission
+            if: steps.checkAccess.outputs.require-result == 'false'
+            run: |
+              echo "For security purposes, ${{ github.triggering_actor }} does not have the required permissions on this repository to safely run this workflow."
+              echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}."
+              echo "Please wait for a collaborator to review your code and re-trigger this workflow."
+              exit 1
+
     create_neon_branch:
         name: Create Neon Branch
+        needs: check_perms
         outputs:
             # db_url: ${{ steps.create_neon_branch.outputs.db_url }}
             # db_url_with_pooler: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}


### PR DESCRIPTION
Read: https://michaelheap.com/access-secrets-from-forks/

- replaces target event from `pull_request` to `pull_request_target`
- add `check_perms` job to verify if user has permissions for workflow to run automatically (i.e. user has write access on the repo)
    - if user doesn't have write perms, the check will fail and the workflow will halt
        - a user with write access is expected to review the PR, and if they decide the code has no security vulnerabilities and it is safe to run the workflow, they should then re-trigger the run 
- remove `workflow_dispatch` option as it's no longer needed